### PR TITLE
Restore the bogus carrier / calculator to unit test active_shipping/b…

### DIFF
--- a/app/models/spree/calculator/shipping/usps/base.rb
+++ b/app/models/spree/calculator/shipping/usps/base.rb
@@ -51,7 +51,6 @@ module Spree
             rate_hash = Hash[*rates.flatten]
             return rate_hash
           rescue ::ActiveShipping::Error => e
-
             if [::ActiveShipping::ResponseError].include?(e.class) && e.response.is_a?(::ActiveShipping::Response)
               params = e.response.params
               if params.has_key?("Response") && params["Response"].has_key?("Error") && params["Response"]["Error"].has_key?("ErrorDescription")

--- a/spec/lib/spree/active_shipping/bogus_carrier.rb
+++ b/spec/lib/spree/active_shipping/bogus_carrier.rb
@@ -8,7 +8,7 @@ module Spree
       end
 
       def find_rates(origin, destination, packages, options = {})
-        RateResponse.new(true, "Bogus rate response.")
+        RateResponse.new(true, "Bogus response")
       end
     end
   end

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -2,12 +2,13 @@ require 'spec_helper'
 
 module ActiveShipping
   describe Spree::Calculator::Shipping do
-    # NOTE: All specs will use the bogus calculator (no login information needed)
+    # NOTE: All specs will use the bogus calculator
+    # (no login information needed)
 
     let(:address) { FactoryGirl.create(:address) }
     let(:stock_location) { FactoryGirl.create(:stock_location) }
     let!(:order) do
-      order = FactoryGirl.create(:order_with_line_items, :ship_address => address, :line_items_count => 2)
+      order = FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2)
       order.line_items.first.tap do |line_item|
         line_item.quantity = 2
         line_item.variant.save
@@ -29,142 +30,144 @@ module ActiveShipping
 
     let(:carrier) { Spree::ActiveShipping::BogusCarrier.new }
     let(:calculator) { Spree::Calculator::Shipping::ActiveShipping::BogusCalculator.new }
-    let(:response) { double('response', :rates => rates, :params => {}) }
+    let(:response) { double('response', rates: rates, params: {}) }
     let(:package) { order.shipments.first.to_package }
 
     before(:each) do
       Spree::StockLocation.destroy_all
       stock_location
       order.create_proposed_shipments
-      order.shipments.count.should == 1
-      Spree::ActiveShipping::Config.set(:units => "imperial")
-      Spree::ActiveShipping::Config.set(:unit_multiplier => 1)
+      expect(order.shipments.count).to eq 1
+      Spree::ActiveShipping::Config.set(units: 'imperial')
+      Spree::ActiveShipping::Config.set(unit_multiplier: 1)
       calculator.stub(:carrier).and_return(carrier)
       Rails.cache.clear
     end
 
-    describe "package.order" do
-      it{ expect(package.order).to eq(order) }
-      it{ expect(package.order.ship_address).to eq(address) }
-      it{ expect(package.order.ship_address.country.iso).to eq('US') }
-      it{ expect(package.stock_location).to eq(stock_location) }
+    describe 'package.order' do
+      it { expect(package.order).to eq(order) }
+      it { expect(package.order.ship_address).to eq(address) }
+      it { expect(package.order.ship_address.country.iso).to eq('US') }
+      it { expect(package.stock_location).to eq(stock_location) }
     end
 
-    describe "available" do
-      context "when rates are available" do
+    describe 'available' do
+      context 'when rates are available' do
         let(:rates) do
-          [ double('rate', :service_name => "Bogus Calculator", :price => 1) ]
+          [double('rate', service_name: 'Bogus Calculator', price: 1)]
         end
 
         before do
-          carrier.should_receive(:find_rates).and_return(response)
+          allow(carrier).to receive(:find_rates) { response }
         end
 
-        it "should return true" do
-          calculator.available?(package).should be(true)
+        it 'should return true' do
+          expect(calculator.available?(package)).to eq true
         end
 
-        it "should use zero as a valid weight for service" do
+        it 'should use zero as a valid weight for service' do
           calculator.stub(:max_weight_for_country).and_return(0)
-          calculator.available?(package).should be(true)
+          expect(calculator.available?(package)).to eq true
         end
       end
 
-      context "when rates are not available" do
+      context 'when rates are not available' do
         let(:rates) { [] }
 
         before do
-          carrier.should_receive(:find_rates).and_return(response)
+          allow(carrier).to receive(:find_rates) { response }
         end
 
-        it "should return false" do
-          calculator.available?(package).should be(false)
+        it 'should return false' do
+          expect(calculator.available?(package)).to eq false
         end
       end
 
-      context "when there is an error retrieving the rates" do
+      context 'when there is an error retrieving the rates' do
         before do
-          carrier.should_receive(:find_rates).and_raise(ActiveShipping::ResponseError)
+          allow(carrier).to receive(:find_rates) { raise ActiveShipping::ResponseError }
         end
 
-        it "should return false" do
-          calculator.available?(package).should be(false)
+        it 'should return false' do
+          expect(calculator.available?(package)).to eq false
         end
       end
     end
 
-    describe "available?" do
+    describe 'available?' do
+      let(:rates) do
+        [double('rate', service_name: 'Bogus Calculator', price: 999)]
+      end
+
       # regression test for #164 and #171
-      it "should not return rates if the weight requirements for the destination country are not met" do
+      it 'should not return rates if the weight requirements for the destination country are not met' do
         # if max_weight_for_country is nil -> the carrier does not ship to that country
         # if max_weight_for_country is 0 -> the carrier does not have weight restrictions to that country
         calculator.stub(:max_weight_for_country).and_return(nil)
-        calculator.should_receive(:is_package_shippable?).and_raise Spree::ShippingError
-        calculator.available?(package).should be(false)
+        expect(calculator).to receive(:is_package_shippable?) { raise Spree::ShippingError }
+        expect(calculator.available?(package)).to eq false
       end
     end
 
-    describe "compute" do
-      it "should use the carrier supplied in the initializer" do
-        carrier.should_receive(:find_rates).and_return(ActiveShipping::RateResponse.new(true, "Foo"))
-        calculator.compute(package)
+    describe 'compute' do
+      subject { calculator.compute(package) }
+
+      let(:rates) do
+        [double('rate', service_name: 'Bogus Calculator', price: 999)]
+      end
+
+      it 'should use the carrier supplied in the initializer' do
+        expect(carrier).to receive(:find_rates) { response }
+        subject
       end
 
       # It's passing but probably because it's not checking anything
-      xit "should ignore variants that have a nil weight" do
+      xit 'should ignore variants that have a nil weight' do
         variant = order.line_items.first.variant
         variant.weight = nil
         variant.save
-        calculator.compute(package)
+        subject
       end
 
-      xit "should create a package with the correct total weight in ounces" do
+      xit 'should create a package with the correct total weight in ounces' do
         # (10 * 2 + 5.25 * 1) * 16 = 404
-        Package.should_receive(:new).with(404, [], :units => :imperial)
-        calculator.compute(package)
+        Package.should_receive(:new).with(404, [], units: :imperial)
+        subject
       end
 
-      it "should check the cache first before finding rates" do
+      it 'should check the cache first before finding rates' do
         Rails.cache.fetch(calculator.send(:cache_key, package)) { Hash.new }
-        carrier.should_not_receive(:find_rates)
-        calculator.compute(package)
+        expect(carrier).not_to receive(:find_rates)
+        subject
       end
 
-      context "with valid response" do
-        let(:rates) do
-          [ double('rate', :service_name => "Bogus Calculator", :price => 999) ]
-        end
-
+      context 'with valid response' do
         before do
-          carrier.should_receive(:find_rates).and_return(response)
+          allow(carrier).to receive(:find_rates) { response }
         end
 
         it "should return rate based on calculator's service_name" do
-          calculator.class.should_receive(:description).and_return("Bogus Calculator")
-          rate = calculator.compute(package)
-          rate.should == 9.99
+          allow(calculator.class).to receive(:description) { 'Bogus Calculator' }
+            expect(subject).to eq 9.99
         end
 
-        it "should include handling_fee when configured" do
-          calculator.class.should_receive(:description).and_return("Bogus Calculator")
-          Spree::ActiveShipping::Config.set(:handling_fee => 100)
-          rate = calculator.compute(package)
-          rate.should == 10.99
+        it 'should include handling_fee when configured' do
+          allow(calculator.class).to receive(:description) { 'Bogus Calculator' }
+          Spree::ActiveShipping::Config.set(handling_fee: 100)
+          expect(subject).to eq 10.99
         end
 
-        it "should return nil if service_name is not found in rate_hash" do
-          calculator.class.should_receive(:description).and_return("Extra-Super Fast")
-          rate = calculator.compute(package)
-          rate.should be_nil
+        it 'should return nil if service_name is not found in rate_hash' do
+          allow(calculator.class).to receive(:description) { 'Service name not found' }
+          expect(subject).to be_nil
         end
       end
     end
 
-    describe "service_name" do
-      it "should return description when not defined" do
-        calculator.class.service_name.should == calculator.description
+    describe 'service_name' do
+      it 'should return description when not defined' do
+        expect(calculator.class.service_name).to eq calculator.description
       end
     end
   end
-
 end

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -20,7 +20,6 @@ describe Spree::Calculator::Shipping do
 
   before(:each) do
     order.create_proposed_shipments
-    expect(order.shipments.count).to eq 1
     Spree::ActiveShipping::Config.set(units: 'imperial')
     Spree::ActiveShipping::Config.set(unit_multiplier: 1)
     Spree::ActiveShipping::Config.set(handling_fee: 0)

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -6,26 +6,12 @@ module ActiveShipping
     # (no login information needed)
 
     let(:address) { FactoryGirl.create(:address) }
+    let(:variant_1) { FactoryGirl.create(:variant, weight: 1) }
+    let(:variant_2) { FactoryGirl.create(:variant, weight: 2) }
     let!(:stock_location) { FactoryGirl.create(:stock_location) }
     let!(:order) do
-      order = FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2)
-      order.line_items.first.tap do |line_item|
-        line_item.quantity = 2
-        line_item.variant.save
-        line_item.variant.weight = 1
-        line_item.variant.save
-        line_item.save
-        # product packages?
-      end
-      order.line_items.last.tap do |line_item|
-        line_item.quantity = 2
-        line_item.variant.save
-        line_item.variant.weight = 2
-        line_item.variant.save
-        line_item.save
-        # product packages?
-      end
-      order
+      FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2,
+                         line_items_attributes: [{ quantity: 2, variant: variant_1}, { quantity: 2, variant: variant_2 }] )
     end
 
     let(:carrier) { Spree::ActiveShipping::BogusCarrier.new }

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -6,7 +6,7 @@ module ActiveShipping
     # (no login information needed)
 
     let(:address) { FactoryGirl.create(:address) }
-    let(:stock_location) { FactoryGirl.create(:stock_location) }
+    let!(:stock_location) { FactoryGirl.create(:stock_location) }
     let!(:order) do
       order = FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2)
       order.line_items.first.tap do |line_item|
@@ -34,8 +34,6 @@ module ActiveShipping
     let(:package) { order.shipments.first.to_package }
 
     before(:each) do
-      Spree::StockLocation.destroy_all
-      stock_location
       order.create_proposed_shipments
       expect(order.shipments.count).to eq 1
       Spree::ActiveShipping::Config.set(units: 'imperial')

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -1,157 +1,155 @@
 require 'spec_helper'
 
-module ActiveShipping
-  describe Spree::Calculator::Shipping do
-    # NOTE: All specs will use the bogus calculator
-    # (no login information needed)
+describe Spree::Calculator::Shipping do
+  # NOTE: All specs will use the bogus calculator
+  # (no login information needed)
 
-    let(:address) { FactoryGirl.create(:address) }
-    let(:variant_1) { FactoryGirl.create(:variant, weight: 1) }
-    let(:variant_2) { FactoryGirl.create(:variant, weight: 2) }
-    let!(:stock_location) { FactoryGirl.create(:stock_location) }
-    let!(:order) do
-      FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2,
-                         line_items_attributes: [{ quantity: 2, variant: variant_1}, { quantity: 2, variant: variant_2 }] )
-    end
+  let(:address) { FactoryGirl.create(:address) }
+  let(:variant_1) { FactoryGirl.create(:variant, weight: 1) }
+  let(:variant_2) { FactoryGirl.create(:variant, weight: 2) }
+  let!(:stock_location) { FactoryGirl.create(:stock_location) }
+  let!(:order) do
+    FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2,
+                       line_items_attributes: [{ quantity: 2, variant: variant_1}, { quantity: 2, variant: variant_2 }] )
+  end
 
-    let(:carrier) { Spree::ActiveShipping::BogusCarrier.new }
-    let(:calculator) { Spree::Calculator::Shipping::ActiveShipping::BogusCalculator.new }
-    let(:response) { double('response', rates: rates, params: {}) }
-    let(:package) { order.shipments.first.to_package }
+  let(:carrier) { Spree::ActiveShipping::BogusCarrier.new }
+  let(:calculator) { Spree::Calculator::Shipping::ActiveShipping::BogusCalculator.new }
+  let(:response) { double('response', rates: rates, params: {}) }
+  let(:package) { order.shipments.first.to_package }
 
-    before(:each) do
-      order.create_proposed_shipments
-      expect(order.shipments.count).to eq 1
-      Spree::ActiveShipping::Config.set(units: 'imperial')
-      Spree::ActiveShipping::Config.set(unit_multiplier: 1)
-      calculator.stub(:carrier).and_return(carrier)
-      Rails.cache.clear
-    end
+  before(:each) do
+    order.create_proposed_shipments
+    expect(order.shipments.count).to eq 1
+    Spree::ActiveShipping::Config.set(units: 'imperial')
+    Spree::ActiveShipping::Config.set(unit_multiplier: 1)
+    calculator.stub(:carrier).and_return(carrier)
+    Rails.cache.clear
+  end
 
-    describe 'package.order' do
-      it { expect(package.order).to eq(order) }
-      it { expect(package.order.ship_address).to eq(address) }
-      it { expect(package.order.ship_address.country.iso).to eq('US') }
-      it { expect(package.stock_location).to eq(stock_location) }
-    end
+  describe 'package.order' do
+    it { expect(package.order).to eq(order) }
+    it { expect(package.order.ship_address).to eq(address) }
+    it { expect(package.order.ship_address.country.iso).to eq('US') }
+    it { expect(package.stock_location).to eq(stock_location) }
+  end
 
-    describe 'available' do
-      context 'when rates are available' do
-        let(:rates) do
-          [double('rate', service_name: 'Bogus Calculator', price: 1)]
-        end
-
-        before do
-          allow(carrier).to receive(:find_rates) { response }
-        end
-
-        it 'should return true' do
-          expect(calculator.available?(package)).to eq true
-        end
-
-        it 'should use zero as a valid weight for service' do
-          calculator.stub(:max_weight_for_country).and_return(0)
-          expect(calculator.available?(package)).to eq true
-        end
-      end
-
-      context 'when rates are not available' do
-        let(:rates) { [] }
-
-        before do
-          allow(carrier).to receive(:find_rates) { response }
-        end
-
-        it 'should return false' do
-          expect(calculator.available?(package)).to eq false
-        end
-      end
-
-      context 'when there is an error retrieving the rates' do
-        before do
-          allow(carrier).to receive(:find_rates) { raise ActiveShipping::ResponseError }
-        end
-
-        it 'should return false' do
-          expect(calculator.available?(package)).to eq false
-        end
-      end
-    end
-
-    describe 'available?' do
+  describe 'available' do
+    context 'when rates are available' do
       let(:rates) do
-        [double('rate', service_name: 'Bogus Calculator', price: 999)]
+        [double('rate', service_name: 'Bogus Calculator', price: 1)]
       end
 
-      # regression test for #164 and #171
-      it 'should not return rates if the weight requirements for the destination country are not met' do
-        # if max_weight_for_country is nil -> the carrier does not ship to that country
-        # if max_weight_for_country is 0 -> the carrier does not have weight restrictions to that country
-        calculator.stub(:max_weight_for_country).and_return(nil)
-        expect(calculator).to receive(:is_package_shippable?) { raise Spree::ShippingError }
+      before do
+        allow(carrier).to receive(:find_rates) { response }
+      end
+
+      it 'should return true' do
+        expect(calculator.available?(package)).to eq true
+      end
+
+      it 'should use zero as a valid weight for service' do
+        calculator.stub(:max_weight_for_country).and_return(0)
+        expect(calculator.available?(package)).to eq true
+      end
+    end
+
+    context 'when rates are not available' do
+      let(:rates) { [] }
+
+      before do
+        allow(carrier).to receive(:find_rates) { response }
+      end
+
+      it 'should return false' do
         expect(calculator.available?(package)).to eq false
       end
     end
 
-    describe 'compute' do
-      subject { calculator.compute(package) }
-
-      let(:rates) do
-        [double('rate', service_name: 'Bogus Calculator', price: 999)]
+    context 'when there is an error retrieving the rates' do
+      before do
+        allow(carrier).to receive(:find_rates) { raise ActiveShipping::ResponseError }
       end
 
-      it 'should use the carrier supplied in the initializer' do
-        expect(carrier).to receive(:find_rates) { response }
-        subject
-      end
-
-      # It's passing but probably because it's not checking anything
-      xit 'should ignore variants that have a nil weight' do
-        variant = order.line_items.first.variant
-        variant.weight = nil
-        variant.save
-        subject
-      end
-
-      xit 'should create a package with the correct total weight in ounces' do
-        # (10 * 2 + 5.25 * 1) * 16 = 404
-        Package.should_receive(:new).with(404, [], units: :imperial)
-        subject
-      end
-
-      it 'should check the cache first before finding rates' do
-        Rails.cache.fetch(calculator.send(:cache_key, package)) { Hash.new }
-        expect(carrier).not_to receive(:find_rates)
-        subject
-      end
-
-      context 'with valid response' do
-        before do
-          allow(carrier).to receive(:find_rates) { response }
-        end
-
-        it "should return rate based on calculator's service_name" do
-          allow(calculator.class).to receive(:description) { 'Bogus Calculator' }
-            expect(subject).to eq 9.99
-        end
-
-        it 'should include handling_fee when configured' do
-          allow(calculator.class).to receive(:description) { 'Bogus Calculator' }
-          Spree::ActiveShipping::Config.set(handling_fee: 100)
-          expect(subject).to eq 10.99
-        end
-
-        it 'should return nil if service_name is not found in rate_hash' do
-          allow(calculator.class).to receive(:description) { 'Service name not found' }
-          expect(subject).to be_nil
-        end
+      it 'should return false' do
+        expect(calculator.available?(package)).to eq false
       end
     end
+  end
 
-    describe 'service_name' do
-      it 'should return description when not defined' do
-        expect(calculator.class.service_name).to eq calculator.description
+  describe 'available?' do
+    let(:rates) do
+      [double('rate', service_name: 'Bogus Calculator', price: 999)]
+    end
+
+    # regression test for #164 and #171
+    it 'should not return rates if the weight requirements for the destination country are not met' do
+      # if max_weight_for_country is nil -> the carrier does not ship to that country
+      # if max_weight_for_country is 0 -> the carrier does not have weight restrictions to that country
+      calculator.stub(:max_weight_for_country).and_return(nil)
+      expect(calculator).to receive(:is_package_shippable?) { raise Spree::ShippingError }
+      expect(calculator.available?(package)).to eq false
+    end
+  end
+
+  describe 'compute' do
+    subject { calculator.compute(package) }
+
+    let(:rates) do
+      [double('rate', service_name: 'Bogus Calculator', price: 999)]
+    end
+
+    it 'should use the carrier supplied in the initializer' do
+      expect(carrier).to receive(:find_rates) { response }
+      subject
+    end
+
+    # It's passing but probably because it's not checking anything
+    xit 'should ignore variants that have a nil weight' do
+      variant = order.line_items.first.variant
+      variant.weight = nil
+      variant.save
+      subject
+    end
+
+    xit 'should create a package with the correct total weight in ounces' do
+      # (10 * 2 + 5.25 * 1) * 16 = 404
+      Package.should_receive(:new).with(404, [], units: :imperial)
+      subject
+    end
+
+    it 'should check the cache first before finding rates' do
+      Rails.cache.fetch(calculator.send(:cache_key, package)) { Hash.new }
+      expect(carrier).not_to receive(:find_rates)
+      subject
+    end
+
+    context 'with valid response' do
+      before do
+        allow(carrier).to receive(:find_rates) { response }
       end
+
+      it "should return rate based on calculator's service_name" do
+        allow(calculator.class).to receive(:description) { 'Bogus Calculator' }
+        expect(subject).to eq 9.99
+      end
+
+      it 'should include handling_fee when configured' do
+        allow(calculator.class).to receive(:description) { 'Bogus Calculator' }
+        Spree::ActiveShipping::Config.set(handling_fee: 100)
+        expect(subject).to eq 10.99
+      end
+
+      it 'should return nil if service_name is not found in rate_hash' do
+        allow(calculator.class).to receive(:description) { 'Service name not found' }
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  describe 'service_name' do
+    it 'should return description when not defined' do
+      expect(calculator.class.service_name).to eq calculator.description
     end
   end
 end

--- a/spec/models/carriers/usps_calculator_spec.rb
+++ b/spec/models/carriers/usps_calculator_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+module ActiveShipping
+  describe Spree::Calculator::Shipping::Usps do
+    WebMock.disable_net_connect!
+
+    let(:address) { FactoryGirl.create(:address) }
+    let(:stock_location) { FactoryGirl.create(:stock_location) }
+    let!(:order) do
+      order = FactoryGirl.create(:order_with_line_items, :ship_address => address, :line_items_count => 2)
+      order.line_items.first.tap do |line_item|
+        line_item.quantity = 2
+        line_item.variant.save
+        line_item.variant.weight = 1
+        line_item.variant.save
+        line_item.save
+        # product packages?
+      end
+      order.line_items.last.tap do |line_item|
+        line_item.quantity = 2
+        line_item.variant.save
+        line_item.variant.weight = 2
+        line_item.variant.save
+        line_item.save
+        # product packages?
+      end
+      order
+    end
+
+    let(:carrier) { ActiveShipping::USPS.new(:login => "FAKEFAKEFAKE") }
+    let(:calculator) { Spree::Calculator::Shipping::Usps::ExpressMail.new }
+    let(:response) { double('response', :rates => rates, :params => {}) }
+    let(:package) { order.shipments.first.to_package }
+
+    before(:each) do
+      Spree::StockLocation.destroy_all
+      stock_location
+      order.create_proposed_shipments
+      order.shipments.count.should == 1
+      Spree::ActiveShipping::Config.set(:units => "imperial")
+      Spree::ActiveShipping::Config.set(:unit_multiplier => 1)
+      calculator.stub(:carrier).and_return(carrier)
+      Rails.cache.clear
+    end
+
+    describe "package.order" do
+      it{ expect(package.order).to eq(order) }
+      it{ expect(package.order.ship_address).to eq(address) }
+      it{ expect(package.order.ship_address.country.iso).to eq('US') }
+      it{ expect(package.stock_location).to eq(stock_location) }
+    end
+
+    describe "compute" do
+      it "should use the carrier supplied in the initializer" do
+        stub_request(:get, /http:\/\/production.shippingapis.com\/ShippingAPI.dll.*/).
+            to_return(:body => fixture(:normal_rates_request))
+        calculator.compute(package).should == 14.1
+      end
+
+      context "with valid response" do
+        let(:rates) do
+          [ double('rate', :service_code => "3", :price => 999) ]
+        end
+
+        before do
+          carrier.should_receive(:find_rates).and_return(response)
+        end
+
+        it "should return rate based on calculator's service_code" do
+          calculator.class.should_receive(:service_code).and_return("dom:3")
+          rate = calculator.compute(package)
+          rate.should == 9.99
+        end
+
+        it "should include handling_fee when configured" do
+          calculator.class.should_receive(:service_code).and_return("dom:3")
+          Spree::ActiveShipping::Config.set(:handling_fee => 100)
+          rate = calculator.compute(package)
+          rate.should == 10.99
+        end
+
+        it "should return nil if service_code is not found in rate_hash" do
+          calculator.class.should_receive(:service_code).and_return("empty_service_code")
+          rate = calculator.compute(package)
+          rate.should be_nil
+        end
+      end
+    end
+
+    describe "service_name" do
+      it "should return description when not defined" do
+        calculator.class.service_name.should == calculator.description
+      end
+    end
+  end
+
+end

--- a/spec/models/carriers/usps_calculator_spec.rb
+++ b/spec/models/carriers/usps_calculator_spec.rb
@@ -16,7 +16,6 @@ describe Spree::Calculator::Shipping::Usps do
 
   before(:each) do
     order.create_proposed_shipments
-    expect(order.shipments.count).to eq 1
     Spree::ActiveShipping::Config.set(units: 'imperial')
     Spree::ActiveShipping::Config.set(unit_multiplier: 1)
     Spree::ActiveShipping::Config.set(handling_fee: 0)

--- a/spec/models/carriers/usps_calculator_spec.rb
+++ b/spec/models/carriers/usps_calculator_spec.rb
@@ -59,6 +59,17 @@ describe Spree::Calculator::Shipping::Usps do
         expect(subject).to be_nil
       end
     end
+
+    context 'with invalid response' do
+      before do
+        allow(calculator).to receive(:carrier).and_return(carrier)
+        allow(carrier).to receive(:find_rates).and_raise(::ActiveShipping::ResponseError)
+      end
+
+      it 'should raise a Spree::ShippingError' do
+        expect{ subject }.to raise_exception(Spree::ShippingError)
+      end
+    end
   end
 
   describe 'service_name' do

--- a/spec/models/carriers/usps_calculator_spec.rb
+++ b/spec/models/carriers/usps_calculator_spec.rb
@@ -5,26 +5,12 @@ module ActiveShipping
     WebMock.disable_net_connect!
 
     let(:address) { FactoryGirl.create(:address) }
+    let(:variant_1) { FactoryGirl.create(:variant, weight: 1) }
+    let(:variant_2) { FactoryGirl.create(:variant, weight: 2) }
     let!(:stock_location) { FactoryGirl.create(:stock_location) }
     let!(:order) do
-      order = FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2)
-      order.line_items.first.tap do |line_item|
-        line_item.quantity = 2
-        line_item.variant.save
-        line_item.variant.weight = 1
-        line_item.variant.save
-        line_item.save
-        # product packages?
-      end
-      order.line_items.last.tap do |line_item|
-        line_item.quantity = 2
-        line_item.variant.save
-        line_item.variant.weight = 2
-        line_item.variant.save
-        line_item.save
-        # product packages?
-      end
-      order
+      FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2,
+                         line_items_attributes: [{ quantity: 2, variant: variant_1}, { quantity: 2, variant: variant_2 }] )
     end
 
     let(:carrier) { ActiveShipping::USPS.new(login: 'FAKEFAKEFAKE') }

--- a/spec/models/carriers/usps_calculator_spec.rb
+++ b/spec/models/carriers/usps_calculator_spec.rb
@@ -1,79 +1,75 @@
 require 'spec_helper'
 
-module ActiveShipping
-  describe Spree::Calculator::Shipping::Usps do
-    WebMock.disable_net_connect!
+describe Spree::Calculator::Shipping::Usps do
+  let(:address) { FactoryGirl.create(:address) }
+  let(:variant_1) { FactoryGirl.create(:variant, weight: 1) }
+  let(:variant_2) { FactoryGirl.create(:variant, weight: 2) }
+  let!(:stock_location) { FactoryGirl.create(:stock_location) }
+  let!(:order) do
+    FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2,
+                       line_items_attributes: [{ quantity: 2, variant: variant_1}, { quantity: 2, variant: variant_2 }] )
+  end
 
-    let(:address) { FactoryGirl.create(:address) }
-    let(:variant_1) { FactoryGirl.create(:variant, weight: 1) }
-    let(:variant_2) { FactoryGirl.create(:variant, weight: 2) }
-    let!(:stock_location) { FactoryGirl.create(:stock_location) }
-    let!(:order) do
-      FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2,
-                         line_items_attributes: [{ quantity: 2, variant: variant_1}, { quantity: 2, variant: variant_2 }] )
-    end
+  let(:carrier) { ActiveShipping::USPS.new(login: 'FAKEFAKEFAKE') }
+  let(:calculator) { Spree::Calculator::Shipping::Usps::ExpressMail.new }
+  let(:response) { double('response', rates: rates, params: {}) }
+  let(:package) { order.shipments.first.to_package }
 
-    let(:carrier) { ActiveShipping::USPS.new(login: 'FAKEFAKEFAKE') }
-    let(:calculator) { Spree::Calculator::Shipping::Usps::ExpressMail.new }
-    let(:response) { double('response', rates: rates, params: {}) }
-    let(:package) { order.shipments.first.to_package }
+  before(:each) do
+    order.create_proposed_shipments
+    expect(order.shipments.count).to eq 1
+    Spree::ActiveShipping::Config.set(units: 'imperial')
+    Spree::ActiveShipping::Config.set(unit_multiplier: 1)
+    allow(calculator).to receive(:carrier) { carrier }
+    Rails.cache.clear
+  end
 
-    before(:each) do
-      order.create_proposed_shipments
-      expect(order.shipments.count).to eq 1
-      Spree::ActiveShipping::Config.set(units: 'imperial')
-      Spree::ActiveShipping::Config.set(unit_multiplier: 1)
-      allow(calculator).to receive(:carrier) { carrier }
-      Rails.cache.clear
-    end
+  describe 'package.order' do
+    it { expect(package.order).to eq(order) }
+    it { expect(package.order.ship_address).to eq(address) }
+    it { expect(package.order.ship_address.country.iso).to eq('US') }
+    it { expect(package.stock_location).to eq(stock_location) }
+  end
 
-    describe 'package.order' do
-      it { expect(package.order).to eq(order) }
-      it { expect(package.order.ship_address).to eq(address) }
-      it { expect(package.order.ship_address.country.iso).to eq('US') }
-      it { expect(package.stock_location).to eq(stock_location) }
-    end
+  describe 'compute' do
+    subject { calculator.compute(package) }
 
-    describe 'compute' do
-      subject { calculator.compute(package) }
-
-      it 'should use the carrier supplied in the initializer' do
-        stub_request(:get, %r{http:\/\/production.shippingapis.com\/ShippingAPI.dll.*})
+    it 'should use the carrier supplied in the initializer' do
+      stub_request(:get, %r{http:\/\/production.shippingapis.com\/ShippingAPI.dll.*})
           .to_return(body: fixture(:normal_rates_request))
-        expect(subject).to eq 14.1
-      end
-
-      context 'with valid response' do
-        let(:rates) do
-          [double('rate', service_code: '3', price: 999)]
-        end
-
-        before do
-          allow(carrier).to receive(:find_rates) { response }
-        end
-
-        it "should return rate based on calculator's service_code" do
-          allow(calculator.class).to receive(:service_code) { 'dom:3' }
-          expect(subject).to eq 9.99
-        end
-
-        it 'should include handling_fee when configured' do
-          allow(calculator.class).to receive(:service_code) { 'dom:3' }
-          Spree::ActiveShipping::Config.set(handling_fee: 100)
-          expect(subject).to eq 10.99
-        end
-
-        it 'should return nil if service_code is not found in rate_hash' do
-          allow(calculator.class).to receive(:service_code) { 'invalid service_code' }
-          expect(subject).to be_nil
-        end
-      end
+      expect(subject).to eq 14.1
     end
 
-    describe 'service_name' do
-      it 'should return description when not defined' do
-        expect(calculator.class.service_name).to eq calculator.description
+    context 'with valid response' do
+      let(:rates) do
+        [double('rate', service_code: '3', price: 999)]
       end
+
+      before do
+        allow(carrier).to receive(:find_rates) { response }
+      end
+
+      it "should return rate based on calculator's service_code" do
+        allow(calculator.class).to receive(:service_code) { 'dom:3' }
+        expect(subject).to eq 9.99
+      end
+
+      it 'should include handling_fee when configured' do
+        allow(calculator.class).to receive(:service_code) { 'dom:3' }
+        Spree::ActiveShipping::Config.set(handling_fee: 100)
+        expect(subject).to eq 10.99
+      end
+
+      it 'should return nil if service_code is not found in rate_hash' do
+        allow(calculator.class).to receive(:service_code) { 'invalid service_code' }
+        expect(subject).to be_nil
+      end
+    end
+  end
+
+  describe 'service_name' do
+    it 'should return description when not defined' do
+      expect(calculator.class.service_name).to eq calculator.description
     end
   end
 end

--- a/spec/models/carriers/usps_calculator_spec.rb
+++ b/spec/models/carriers/usps_calculator_spec.rb
@@ -5,7 +5,7 @@ module ActiveShipping
     WebMock.disable_net_connect!
 
     let(:address) { FactoryGirl.create(:address) }
-    let(:stock_location) { FactoryGirl.create(:stock_location) }
+    let!(:stock_location) { FactoryGirl.create(:stock_location) }
     let!(:order) do
       order = FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2)
       order.line_items.first.tap do |line_item|
@@ -33,8 +33,6 @@ module ActiveShipping
     let(:package) { order.shipments.first.to_package }
 
     before(:each) do
-      Spree::StockLocation.destroy_all
-      stock_location
       order.create_proposed_shipments
       expect(order.shipments.count).to eq 1
       Spree::ActiveShipping::Config.set(units: 'imperial')

--- a/spec/models/carriers/usps_calculator_spec.rb
+++ b/spec/models/carriers/usps_calculator_spec.rb
@@ -7,7 +7,7 @@ module ActiveShipping
     let(:address) { FactoryGirl.create(:address) }
     let(:stock_location) { FactoryGirl.create(:stock_location) }
     let!(:order) do
-      order = FactoryGirl.create(:order_with_line_items, :ship_address => address, :line_items_count => 2)
+      order = FactoryGirl.create(:order_with_line_items, ship_address: address, line_items_count: 2)
       order.line_items.first.tap do |line_item|
         line_item.quantity = 2
         line_item.variant.save
@@ -27,71 +27,69 @@ module ActiveShipping
       order
     end
 
-    let(:carrier) { ActiveShipping::USPS.new(:login => "FAKEFAKEFAKE") }
+    let(:carrier) { ActiveShipping::USPS.new(login: 'FAKEFAKEFAKE') }
     let(:calculator) { Spree::Calculator::Shipping::Usps::ExpressMail.new }
-    let(:response) { double('response', :rates => rates, :params => {}) }
+    let(:response) { double('response', rates: rates, params: {}) }
     let(:package) { order.shipments.first.to_package }
 
     before(:each) do
       Spree::StockLocation.destroy_all
       stock_location
       order.create_proposed_shipments
-      order.shipments.count.should == 1
-      Spree::ActiveShipping::Config.set(:units => "imperial")
-      Spree::ActiveShipping::Config.set(:unit_multiplier => 1)
-      calculator.stub(:carrier).and_return(carrier)
+      expect(order.shipments.count).to eq 1
+      Spree::ActiveShipping::Config.set(units: 'imperial')
+      Spree::ActiveShipping::Config.set(unit_multiplier: 1)
+      allow(calculator).to receive(:carrier) { carrier }
       Rails.cache.clear
     end
 
-    describe "package.order" do
-      it{ expect(package.order).to eq(order) }
-      it{ expect(package.order.ship_address).to eq(address) }
-      it{ expect(package.order.ship_address.country.iso).to eq('US') }
-      it{ expect(package.stock_location).to eq(stock_location) }
+    describe 'package.order' do
+      it { expect(package.order).to eq(order) }
+      it { expect(package.order.ship_address).to eq(address) }
+      it { expect(package.order.ship_address.country.iso).to eq('US') }
+      it { expect(package.stock_location).to eq(stock_location) }
     end
 
-    describe "compute" do
-      it "should use the carrier supplied in the initializer" do
-        stub_request(:get, /http:\/\/production.shippingapis.com\/ShippingAPI.dll.*/).
-            to_return(:body => fixture(:normal_rates_request))
-        calculator.compute(package).should == 14.1
+    describe 'compute' do
+      subject { calculator.compute(package) }
+
+      it 'should use the carrier supplied in the initializer' do
+        stub_request(:get, %r{http:\/\/production.shippingapis.com\/ShippingAPI.dll.*})
+          .to_return(body: fixture(:normal_rates_request))
+        expect(subject).to eq 14.1
       end
 
-      context "with valid response" do
+      context 'with valid response' do
         let(:rates) do
-          [ double('rate', :service_code => "3", :price => 999) ]
+          [double('rate', service_code: '3', price: 999)]
         end
 
         before do
-          carrier.should_receive(:find_rates).and_return(response)
+          allow(carrier).to receive(:find_rates) { response }
         end
 
         it "should return rate based on calculator's service_code" do
-          calculator.class.should_receive(:service_code).and_return("dom:3")
-          rate = calculator.compute(package)
-          rate.should == 9.99
+          allow(calculator.class).to receive(:service_code) { 'dom:3' }
+          expect(subject).to eq 9.99
         end
 
-        it "should include handling_fee when configured" do
-          calculator.class.should_receive(:service_code).and_return("dom:3")
-          Spree::ActiveShipping::Config.set(:handling_fee => 100)
-          rate = calculator.compute(package)
-          rate.should == 10.99
+        it 'should include handling_fee when configured' do
+          allow(calculator.class).to receive(:service_code) { 'dom:3' }
+          Spree::ActiveShipping::Config.set(handling_fee: 100)
+          expect(subject).to eq 10.99
         end
 
-        it "should return nil if service_code is not found in rate_hash" do
-          calculator.class.should_receive(:service_code).and_return("empty_service_code")
-          rate = calculator.compute(package)
-          rate.should be_nil
+        it 'should return nil if service_code is not found in rate_hash' do
+          allow(calculator.class).to receive(:service_code) { 'invalid service_code' }
+          expect(subject).to be_nil
         end
       end
     end
 
-    describe "service_name" do
-      it "should return description when not defined" do
-        calculator.class.service_name.should == calculator.description
+    describe 'service_name' do
+      it 'should return description when not defined' do
+        expect(calculator.class.service_name).to eq calculator.description
       end
     end
   end
-
 end


### PR DESCRIPTION
active_shipping_calculator_spec.rb is in a weird state since it's testing with a USPS calculators, who decorates the base methods like find_rates from active_shipping/base.rb

So this PR is to : 

1) Restore the use of bogus carrier / calculator in the active_shipping_calculator_spec to unit tests the code present in active_shipping/base.rb

2) Extract the USPS specific code into a new carrier spec as a first step
