### PR TITLE
Add integration test for UPS calculators

### DIFF
--- a/spec/factories/order_factory_override.rb
+++ b/spec/factories/order_factory_override.rb
@@ -1,0 +1,47 @@
+require 'spree/testing_support/factories/order_factory'
+
+FactoryGirl.define do
+  # The order with line items factory was updated in 1.2 to take a stock
+  # location as a transient attribute. This brings that change so we can
+  # specify the stock location which is used for the origin address for packages
+  # and can be removed when we no longer want to support Solidus 1.0 and 1.1.
+  factory :order_with_line_items_and_stock_location, parent: :order do
+    bill_address
+    ship_address
+
+    transient do
+      line_items_count 1
+      line_items_attributes { [{}] * line_items_count }
+      shipment_cost 100
+      shipping_method nil
+      stock_location { create(:stock_location) }
+    end
+
+    after(:create) do |order, evaluator|
+      evaluator.stock_location # must evaluate before creating line items
+
+      evaluator.line_items_attributes.each do |attributes|
+        attributes = {
+          order: order,
+          price: evaluator.line_items_price
+        }.merge(attributes)
+
+        create(:line_item, attributes)
+      end
+      order.line_items.reload
+
+      create(
+        :shipment,
+        order: order,
+        cost: evaluator.shipment_cost,
+        shipping_method: evaluator.shipping_method,
+        address: evaluator.ship_address,
+        stock_location: evaluator.stock_location
+      )
+
+      order.shipments.reload
+
+      order.update!
+    end
+  end
+end

--- a/spec/features/checkout_spec.rb
+++ b/spec/features/checkout_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe "Checkout", type: :feature do
+  include_context 'US stock location'
   include_context 'checkout setup'
   include CheckoutHelper
 

--- a/spec/integrations/calculators/ups_spec.rb
+++ b/spec/integrations/calculators/ups_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe 'UPS calculators' do
+  include_context 'UPS setup'
+  include_context 'package setup'
+
+  subject { described_class.new.compute_package(package) }
+
+  context 'with Canadian origin address' do
+    include_context 'Canada stock location'
+
+    describe Spree::Calculator::Shipping::Ups::Express do
+      it { is_expected.to eq(139.1) }
+    end
+
+    describe Spree::Calculator::Shipping::Ups::WorldwideExpedited  do
+      it { is_expected.to eq(97.15) }
+    end
+
+    describe Spree::Calculator::Shipping::Ups::Saver do
+      it { is_expected.to eq(132.25) }
+    end
+
+    describe Spree::Calculator::Shipping::Ups::Standard do
+      it { is_expected.to eq(35.34) }
+    end
+
+    describe Spree::Calculator::Shipping::Ups::ThreeDaySelect do
+      it { is_expected.to eq(89.7) }
+    end
+  end
+
+  context 'with US origin address' do
+    include_context 'US stock location'
+
+    describe Spree::Calculator::Shipping::Ups::Ground do
+      it { is_expected.to eq(14.2) }
+    end
+
+    describe Spree::Calculator::Shipping::Ups::NextDayAir do
+      it { is_expected.to eq(79.47) }
+    end
+
+    describe Spree::Calculator::Shipping::Ups::NextDayAirEarlyAm do
+      it { is_expected.to eq(110.29) }
+    end
+
+    describe Spree::Calculator::Shipping::Ups::NextDayAirSaver do
+      it { is_expected.to eq(77.46) }
+    end
+
+    describe Spree::Calculator::Shipping::Ups::SecondDayAir do
+      it { is_expected.to eq(27.97) }
+    end
+  end
+end

--- a/spec/support/shared_contexts/checkout_setup.rb
+++ b/spec/support/shared_contexts/checkout_setup.rb
@@ -1,12 +1,11 @@
 shared_context 'checkout setup' do
   let!(:store) { create(:store) }
-  let!(:stock_location) { create :stock_location,
-    address1: '1600 Pennsylvania Ave NW',
-    city: 'Washington',
-    zipcode: '20500',
-    state: create(:state_with_autodiscover, state_code: 'DC')
-  }
-  let!(:shipping_method) { create(:shipping_method, calculator: Spree::Calculator::Shipping::Ups::NextDayAir.new) }
+  let!(:shipping_method) do
+    create(
+      :shipping_method,
+      calculator: Spree::Calculator::Shipping::Ups::NextDayAir.new
+    )
+  end
   let!(:payment_method) { create(:check_payment_method) }
   let!(:zone) { create(:zone) }
   let!(:mug) { create(:product, name: 'RoR Mug', weight: 2) }

--- a/spec/support/shared_contexts/package_setup.rb
+++ b/spec/support/shared_contexts/package_setup.rb
@@ -1,0 +1,33 @@
+shared_context 'package setup' do
+  let(:destination) { create :address,
+                      firstname: 'John',
+                      lastname: 'Doe',
+                      company: 'Company',
+                      address1: '5145 North California Avenue',
+                      city: 'Chicago',
+                      state: create(:state_with_autodiscover, state_code: 'IL'),
+                      zipcode: '60601',
+                      phone: "(555) 555-5555"
+  }
+  let(:variant_1) { FactoryGirl.create(:variant, weight: 1) }
+  let(:variant_2) { FactoryGirl.create(:variant, weight: 2) }
+  let(:order) do
+    FactoryGirl.create(
+      :order_with_line_items,
+      stock_location: stock_location,
+      ship_address: destination,
+      line_items_count: 2,
+      line_items_attributes: [
+        {
+          quantity: 2,
+          variant: variant_1
+        },
+        {
+          quantity: 2,
+          variant: variant_2
+        }
+      ]
+    )
+  end
+  let(:package) { order.shipments.first.to_package }
+end

--- a/spec/support/shared_contexts/package_setup.rb
+++ b/spec/support/shared_contexts/package_setup.rb
@@ -13,8 +13,9 @@ shared_context 'package setup' do
   let(:variant_2) { FactoryGirl.create(:variant, weight: 2) }
   let(:order) do
     FactoryGirl.create(
-      :order_with_line_items,
+      :order_with_line_items_and_stock_location,
       stock_location: stock_location,
+      bill_address: destination,
       ship_address: destination,
       line_items_count: 2,
       line_items_attributes: [

--- a/spec/support/shared_contexts/shipping_carriers/ups.rb
+++ b/spec/support/shared_contexts/shipping_carriers/ups.rb
@@ -5,6 +5,7 @@ shared_context 'UPS setup' do
     shipping_config.ups_login = 'solidusdev'
     shipping_config.ups_password = 'S0lidusdev'
     shipping_config.ups_key = '9D0B1B1E0A6389A8'
+    shipping_config.test_mode = true
   end
 
   after do

--- a/spec/support/shared_contexts/stock_location_setup.rb
+++ b/spec/support/shared_contexts/stock_location_setup.rb
@@ -1,0 +1,26 @@
+shared_context 'Canada stock location' do
+  let(:ontario) do
+    create(:state_with_autodiscover, country_iso: 'CA', state_code: 'ON')
+  end
+  let!(:stock_location) do
+    create(
+      :stock_location,
+      name: 'Canda Warehouse',
+      address1: '123 Test Street',
+      city: 'Ottawa',
+      zipcode: 'K1P1J1',
+      state: ontario,
+      country: ontario.country
+    )
+  end
+end
+
+shared_context 'US stock location' do
+  let!(:stock_location) do
+    create :stock_location,
+      address1: '1600 Pennsylvania Ave NW',
+      city: 'Washington',
+      zipcode: '20500',
+      state: create(:state_with_autodiscover, state_code: 'DC')
+  end
+end


### PR DESCRIPTION
This change builds on Kevin's work for adding integration tests for the UPS shipping calculators and
extracts the setup needed into shared contexts. The idea is to provide a framework we can use for integration tests for all the provides we have calculators for.

This change relies on the `:order_with_line_items` factory having a transient attribute for `stock_location`, which was added in v1.2, so it adds a commit that brings that into the extension to make tests pass in Spree 1.0 and 1.1.
