### PR TITLE
Improve specs with transpec

### DIFF
--- a/spec/controllers/admin/active_shipping_settings_controller_spec.rb
+++ b/spec/controllers/admin/active_shipping_settings_controller_spec.rb
@@ -6,8 +6,8 @@ describe Spree::Admin::ActiveShippingSettingsController do
   context '#edit' do
     it 'should assign a Spree::ActiveShippingConfiguration and render the view' do
       spree_get :edit
-      assigns(:config).should be_an_instance_of(Spree::ActiveShippingConfiguration)
-      response.should render_template('edit')
+      expect(assigns(:config)).to be_an_instance_of(Spree::ActiveShippingConfiguration)
+      expect(response).to render_template('edit')
     end
   end
 
@@ -31,7 +31,7 @@ describe Spree::Admin::ActiveShippingSettingsController do
     context 'without existing value' do
       it "doesn't produce an error" do
         spree_post :update, 'not_real_parameter_name' => 'not_real'
-        response.should redirect_to(spree.edit_admin_active_shipping_settings_path)
+        expect(response).to redirect_to(spree.edit_admin_active_shipping_settings_path)
       end
     end
   end

--- a/spec/controllers/admin/product_packages_controller_spec.rb
+++ b/spec/controllers/admin/product_packages_controller_spec.rb
@@ -8,9 +8,9 @@ describe Spree::Admin::ProductPackagesController do
 
     it 'should find ProductPackages for the product and render the view' do
       spree_get :index, product_id: product.slug
-      assigns(:product).should eq(product)
-      response.should be_ok
-      response.should render_template('index')
+      expect(assigns(:product)).to eq(product)
+      expect(response).to be_ok
+      expect(response).to render_template('index')
     end
   end
 
@@ -27,10 +27,10 @@ describe Spree::Admin::ProductPackagesController do
                           product_package: { length: new_length, width: new_width, 
                                              height: new_height, weight: new_weight }
       product_package.reload
-      product_package.length.should eq(new_length)
-      product_package.width.should eq(new_width)
-      product_package.height.should eq(new_height)
-      product_package.weight.should eq(new_weight)
+      expect(product_package.length).to eq(new_length)
+      expect(product_package.width).to eq(new_width)
+      expect(product_package.height).to eq(new_height)
+      expect(product_package.weight).to eq(new_weight)
     end
   end
 end

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -51,7 +51,7 @@ describe Spree::Calculator::Shipping do
       end
 
       it 'should use zero as a valid weight for service' do
-        calculator.stub(:max_weight_for_country).and_return(0)
+        allow(calculator).to receive(:max_weight_for_country).and_return(0)
         expect(calculator.available?(package)).to eq true
       end
     end
@@ -88,7 +88,7 @@ describe Spree::Calculator::Shipping do
     it 'should not return rates if the weight requirements for the destination country are not met' do
       # if max_weight_for_country is nil -> the carrier does not ship to that country
       # if max_weight_for_country is 0 -> the carrier does not have weight restrictions to that country
-      calculator.stub(:max_weight_for_country).and_return(nil)
+      allow(calculator).to receive(:max_weight_for_country).and_return(nil)
       expect(calculator).to receive(:is_package_shippable?).and_raise(Spree::ShippingError)
       expect(calculator.available?(package)).to eq false
     end
@@ -116,7 +116,7 @@ describe Spree::Calculator::Shipping do
 
     xit 'should create a package with the correct total weight in ounces' do
       # (10 * 2 + 5.25 * 1) * 16 = 404
-      Package.should_receive(:new).with(404, [], units: :imperial)
+      expect(Package).to receive(:new).with(404, [], units: :imperial)
       subject
     end
 

--- a/spec/models/weight_limits_spec.rb
+++ b/spec/models/weight_limits_spec.rb
@@ -103,14 +103,14 @@ module ActiveShipping
 
         it "should create array of packages" do
           packages = international_calculator.send :packages, package
-          packages.size.should == 5
-          packages.map{|package| package.weight.amount}.should == [61.0, 60.0, 60.0, 40.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
-          packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
+          expect(packages.size).to eq(5)
+          expect(packages.map{|package| package.weight.amount}).to eq([61.0, 60.0, 60.0, 40.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]})
+          expect(packages.map{|package| package.weight.unit}.uniq).to eq([:ounces])
         end
 
         context "raise exception if max weight exceeded" do
           it "should get Spree::ShippingError" do
-            too_heavy_package.stub(:weight) do
+            allow(too_heavy_package).to receive(:weight) do
               too_heavy_package.contents.sum{ |item| item.variant.weight * item.quantity }
             end
             expect { international_calculator.compute(too_heavy_package) }.to raise_error(Spree::ShippingError)
@@ -121,33 +121,33 @@ module ActiveShipping
       context "for domestic calculators" do
         it "should not convert order line items to weights array for US" do
           weights = domestic_calculator.send :convert_package_to_weights_array, us_package
-          weights.should == [5.25, 5.25, 5.25, 5.25, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
+          expect(weights).to eq([5.25, 5.25, 5.25, 5.25, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]})
         end
 
         it "should create array with one package for US" do
           packages = domestic_calculator.send :packages, us_package
-          packages.size.should == 4
-          packages.map{|package| package.weight.amount}.should == [61.0, 60.0, 60.0, 69.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
-          packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
+          expect(packages.size).to eq(4)
+          expect(packages.map{|package| package.weight.amount}).to eq([61.0, 60.0, 60.0, 69.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]})
+          expect(packages.map{|package| package.weight.unit}.uniq).to eq([:ounces])
         end
       end
     end
 
     describe "weight limits" do
       it "should be set for USPS calculators" do
-        international_calculator.send(:max_weight_for_country, country).should == 66.0 * Spree::ActiveShipping::Config[:unit_multiplier] # Canada
-        domestic_calculator.send(:max_weight_for_country, country).should == 70.0 * Spree::ActiveShipping::Config[:unit_multiplier]
+        expect(international_calculator.send(:max_weight_for_country, country)).to eq(66.0 * Spree::ActiveShipping::Config[:unit_multiplier]) # Canada
+        expect(domestic_calculator.send(:max_weight_for_country, country)).to eq(70.0 * Spree::ActiveShipping::Config[:unit_multiplier])
       end
 
       it "should respect the max weight per package" do
         Spree::ActiveShipping::Config.set(:max_weight_per_package => 30)
         weights = international_calculator.send :convert_package_to_weights_array, package
-        weights.should == [5.25, 5.25, 5.25, 5.25, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
+        expect(weights).to eq([5.25, 5.25, 5.25, 5.25, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]})
 
         packages = international_calculator.send :packages, package
-        packages.size.should == 12
-        packages.map{|package| package.weight.amount}.should == [21.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
-        packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
+        expect(packages.size).to eq(12)
+        expect(packages.map{|package| package.weight.amount}).to eq([21.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]})
+        expect(packages.map{|package| package.weight.unit}.uniq).to eq([:ounces])
       end
     end
 
@@ -155,7 +155,7 @@ module ActiveShipping
       it "should avoid zero weight or negative weight" do
         weights = domestic_calculator.send :convert_package_to_weights_array, package_with_invalid_weights
         default_weight = Spree::ActiveShipping::Config[:default_weight] * Spree::ActiveShipping::Config[:unit_multiplier]
-        weights.should == [default_weight, default_weight]
+        expect(weights).to eq([default_weight, default_weight])
       end
     end
 
@@ -163,16 +163,16 @@ module ActiveShipping
       it "should accept zero default weight" do
         Spree::ActiveShipping::Config.set(:default_weight => 0)
         weights = domestic_calculator.send :convert_package_to_weights_array, package_with_invalid_weights
-        weights.should == [0, 0]
+        expect(weights).to eq([0, 0])
       end
     end
 
     describe "adds item packages" do
       it "should add item packages to weight calculation" do
         packages = domestic_calculator.send :packages, package_with_packages
-        packages.size.should == 6
-        packages.map{|package| package.weight.amount}.should == [50, 29, 36, 43, 36, 43].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
-        packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
+        expect(packages.size).to eq(6)
+        expect(packages.map{|package| package.weight.amount}).to eq([50, 29, 36, 43, 36, 43].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]})
+        expect(packages.map{|package| package.weight.unit}.uniq).to eq([:ounces])
       end
     end
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -10,4 +10,15 @@ RSpec.configure do |config|
   Capybara.register_driver(:poltergeist) do |app|
     Capybara::Poltergeist::Driver.new app, js_errors: true, timeout: 60
   end
+
+  # rspec-rails 3 will no longer automatically infer an example group's spec type
+  # from the file location. You can explicitly opt-in to the feature using this
+  # config option.
+  # To explicitly tag specs without using automatic inference, set the `:type`
+  # metadata manually:
+  #
+  #     describe ThingsController, :type => :controller do
+  #       # Equivalent to being in spec/controllers
+  #     end
+  config.infer_spec_type_from_file_location!
 end


### PR DESCRIPTION
Ran transpec to standardize the syntax everywhere and remove the deprecation messages related to the outdated syntax.
