### PR TITLE
Improve Bogus carrier and limit stub usage

### DIFF
--- a/spec/lib/spree/active_shipping/bogus_carrier.rb
+++ b/spec/lib/spree/active_shipping/bogus_carrier.rb
@@ -3,12 +3,15 @@ module Spree
     # Bogus carrier useful for testing.  For some reasons the plugin version of this class does not work
     # properly (it fails to return a RateResponse)
     class BogusCarrier < ::ActiveShipping::Carrier
+      include RSpec::Mocks::ExampleMethods
+
       def name
         "BogusCarrier"
       end
 
+      # We're stubbing the rates because actual RateEstimate are too elaborate
       def find_rates(origin, destination, packages, options = {})
-        RateResponse.new(true, "Bogus response")
+        ::ActiveShipping::RateResponse.new(true, "success!", {}, :rates => [instance_double('rate', service_name: 'Bogus Calculator', price: 999)], :xml => "")
       end
     end
   end

--- a/spec/lib/spree/calculator/shipping/bogus_calculator.rb
+++ b/spec/lib/spree/calculator/shipping/bogus_calculator.rb
@@ -1,11 +1,9 @@
 module Spree
   module Calculator::Shipping
     module ActiveShipping
-      # Bogus calculator for testing purposes.  Uses the common functionality of ActiveShippingCalcualtor but
-      # doesn't actually use a real carrier to obtain rates.
       class BogusCalculator < Spree::Calculator::Shipping::ActiveShipping::Base
         def carrier
-          Spree::ActiveShipping::BogusCarrier
+          Spree::ActiveShipping::BogusCarrier.new
         end
 
         def self.description

--- a/spec/lib/spree/calculator/shipping/bogus_calculator.rb
+++ b/spec/lib/spree/calculator/shipping/bogus_calculator.rb
@@ -1,9 +1,11 @@
+require 'spec_helper'
+
 module Spree
   module Calculator::Shipping
     module ActiveShipping
       class BogusCalculator < Spree::Calculator::Shipping::ActiveShipping::Base
         def carrier
-          Spree::ActiveShipping::BogusCarrier.new
+          @carrier ||= Spree::ActiveShipping::BogusCarrier.new
         end
 
         def self.description

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -83,12 +83,7 @@ describe Spree::Calculator::Shipping do
 
   describe 'compute' do
     subject { calculator.compute(package) }
-
-    it 'should use the carrier supplied in the initializer' do
-      expect(calculator.carrier).to be_an_instance_of(carrier.class)
-      subject
-    end
-
+    
     # It's passing but probably because it's not checking anything
     xit 'should ignore variants that have a nil weight' do
       variant = order.line_items.first.variant


### PR DESCRIPTION
Current spec is using fake classes but stubs every functions call and responses. This PR fixes the Bogus carrier / Bogus calculator so they can be used in the same manner as the live carriers / calculators

Instead of stubbing every function calls, we're just stubbing the responses when we need to raise errors or return empty/wrong response
