### PR TITLE
Remove duplicate product submenu

### DIFF
--- a/app/views/spree/admin/product_packages/index.html.erb
+++ b/app/views/spree/admin/product_packages/index.html.erb
@@ -6,7 +6,8 @@
   <%= javascript_include_tag 'admin/product_packages/index.js' %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
+<%# This partial was remove in solidus 1.2 but that is also when Spree.solidus_version was added %>
+<%= render :partial => 'spree/admin/shared/product_sub_menu' if !Spree.respond_to?(:solidus_version) %>
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Packages' } %>
 
 <div id="product_packages" data-hook></div>


### PR DESCRIPTION
I have a feeling we're going to be adding this to a lot of gems as long as we want to support old solidus.
