### PR TITLE
Fix Rails 5 deprecation warning on timestamps

### DIFF
--- a/db/migrate/20130107030221_create_product_packages.rb
+++ b/db/migrate/20130107030221_create_product_packages.rb
@@ -6,7 +6,7 @@ class CreateProductPackages < ActiveRecord::Migration
       t.integer "width",      :default => 0, :null => false
       t.integer "height",     :default => 0, :null => false
       t.integer "weight",     :default => 0, :null => false
-      t.timestamps
+      t.timestamps :null => false
     end
   end
 end


### PR DESCRIPTION
Add nullable false to timestamps to silence the warning/correct the deprecation added by Rails 5
