### PR TITLE
Remove address from shipment in order_factory override

### DIFF
--- a/spec/factories/order_factory_override.rb
+++ b/spec/factories/order_factory_override.rb
@@ -35,7 +35,6 @@ FactoryGirl.define do
         order: order,
         cost: evaluator.shipment_cost,
         shipping_method: evaluator.shipping_method,
-        address: evaluator.ship_address,
         stock_location: evaluator.stock_location
       )
 


### PR DESCRIPTION
Solidus PR#1138 deprecated the address field in the shipment model, the edited factory was still using this field, causing test failures everywhere.
