### PR TITLE
Replace deprecated Spree::Core::Engine.add_routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Spree::Core::Engine.add_routes do
+Spree::Core::Engine.routes.draw do
   namespace :admin do
     resource :active_shipping_settings, :only => ['show', 'update', 'edit']
 


### PR DESCRIPTION
On master, usage of Spree::Core::Engine.add_routes is deprecated. As such, the extension is not  usable. This commit is replacing the deprecated method with the recommended one as specified by the
deprecation message.
