### PR TITLE
Fix Rails 5 deprecation warnings

### DIFF
--- a/app/controllers/spree/admin/product_packages_controller.rb
+++ b/app/controllers/spree/admin/product_packages_controller.rb
@@ -2,7 +2,7 @@ module Spree
   module Admin
     class ProductPackagesController < ResourceController
       belongs_to 'spree/product', :find_by => :slug
-      before_filter :load_data
+      before_action :load_data
 
       private
         def load_data

--- a/spec/controllers/admin/active_shipping_settings_controller_spec.rb
+++ b/spec/controllers/admin/active_shipping_settings_controller_spec.rb
@@ -5,7 +5,7 @@ describe Spree::Admin::ActiveShippingSettingsController do
 
   context '#edit' do
     it 'should assign a Spree::ActiveShippingConfiguration and render the view' do
-      spree_get :edit
+      get :edit
       expect(assigns(:config)).to be_an_instance_of(Spree::ActiveShippingConfiguration)
       expect(response).to render_template('edit')
     end
@@ -23,14 +23,14 @@ describe Spree::Admin::ActiveShippingSettingsController do
 
       it "updates the existing value" do
         expect(config.has_preference?(:default_weight)).to be(true)
-        spree_post :update, default_weight: 42
+        post :update, params: { default_weight: 42 }
         expect(config.send("preferred_default_weight")).to be(42)
       end
     end
 
     context 'without existing value' do
       it "doesn't produce an error" do
-        spree_post :update, 'not_real_parameter_name' => 'not_real'
+        post :update, params: { 'not_real_parameter_name' => 'not_real' }
         expect(response).to redirect_to(spree.edit_admin_active_shipping_settings_path)
       end
     end

--- a/spec/controllers/admin/product_packages_controller_spec.rb
+++ b/spec/controllers/admin/product_packages_controller_spec.rb
@@ -7,7 +7,7 @@ describe Spree::Admin::ProductPackagesController do
     let(:product) { create(:product) }
 
     it 'should find ProductPackages for the product and render the view' do
-      spree_get :index, product_id: product.slug
+      get :index, params: { product_id: product.slug }
       expect(assigns(:product)).to eq(product)
       expect(response).to be_ok
       expect(response).to render_template('index')
@@ -23,9 +23,9 @@ describe Spree::Admin::ProductPackagesController do
       new_width = SecureRandom.random_number(19) + 1
       new_height = SecureRandom.random_number(19) + 1
       new_weight = SecureRandom.random_number(19) + 1
-      spree_post :update, product_id: product.slug, id: product_package.id,
+      post :update, params: {product_id: product.slug, id: product_package.id,
                           product_package: { length: new_length, width: new_width, 
-                                             height: new_height, weight: new_weight }
+                                             height: new_height, weight: new_weight } }
       product_package.reload
       expect(product_package.length).to eq(new_length)
       expect(product_package.width).to eq(new_width)


### PR DESCRIPTION
1) Edit verb related syntax from the controller tests to match the format
expected by Rails 5

2) Replace before_filter by before_action
