### PR TITLE
Replace pending tests

### DIFF
--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -73,20 +73,6 @@ describe Spree::Calculator::Shipping do
   describe 'compute' do
     subject { calculator.compute(package) }
 
-    # It's passing but probably because it's not checking anything
-    xit 'should ignore variants that have a nil weight' do
-      variant = order.line_items.first.variant
-      variant.weight = nil
-      variant.save
-      subject
-    end
-
-    xit 'should create a package with the correct total weight in ounces' do
-      # (10 * 2 + 5.25 * 1) * 16 = 404
-      expect(Package).to receive(:new).with(404, [], units: :imperial)
-      subject
-    end
-
     context 'when the cache is warm' do
       it 'should check the cache first before finding rates' do
         # Since the cache is cleared between the tests, cache.fetch will return a miss,

--- a/spec/models/package_builder_spec.rb
+++ b/spec/models/package_builder_spec.rb
@@ -31,6 +31,24 @@ describe Spree::PackageBuilder do
       expect(subject.sum(&:weight)).to eq (package.weight * 2)
     end
 
+    context 'when one product has a zero weight' do
+      let(:variant_1) { FactoryGirl.create(:variant, weight: 0) }
+
+      it 'ignores products with nil weight' do
+        expect(subject.sum(&:weight)).to eq (variant_2.weight * 2)
+      end
+    end
+
+    context 'when one product has a nil weight' do
+      let(:variant_1) { FactoryGirl.create(:variant, weight: nil) }
+      let(:variant_2) { FactoryGirl.create(:variant, weight: nil) }
+      let(:default_weight) { Spree::ActiveShipping::Config[:default_weight] }
+
+      it 'use the default_weight as a weight value' do
+        expect(subject.sum(&:weight)).to eq( default_weight * 4 )
+      end
+    end
+
     context 'with an order containing only products with associated product_packages' do
       let(:product_weight) { 20 }
       let(:product_package1) { FactoryGirl.create(:product_package, weight: product_weight) }
@@ -42,7 +60,7 @@ describe Spree::PackageBuilder do
           product: build(
             :product,
             product_packages: [product_package1, product_package2]
-          )
+        )
         )
       end
 
@@ -130,7 +148,7 @@ describe Spree::PackageBuilder do
           product: build(
             :product,
             product_packages: [product_package1, product_package2]
-          )
+        )
         )
       end
 


### PR DESCRIPTION
Remove the pending tests and replace them by other tests in the
appropriate spec if needed

1) should ignore variants that have a nil weight is covered by a new
test in the package builder spec

2) should create a package with the correct total weight (ounces doesn't
matter) is covered by existing tests in the package_builder spec
