### PR TITLE
Remove extra :test_mode from CanadaPostPws prefs

### DIFF
--- a/app/controllers/spree/admin/active_shipping_settings_controller.rb
+++ b/app/controllers/spree/admin/active_shipping_settings_controller.rb
@@ -5,7 +5,7 @@ class Spree::Admin::ActiveShippingSettingsController < Spree::Admin::BaseControl
     @preferences_FedEx = [:fedex_login, :fedex_password, :fedex_account, :fedex_key]
     @preferences_USPS = [:usps_login]
     @preferences_CanadaPost = [:canada_post_login]
-    @preferences_CanadaPostPws = [:canada_post_pws_userid, :canada_post_pws_password, :test_mode,
+    @preferences_CanadaPostPws = [:canada_post_pws_userid, :canada_post_pws_password,
       :canada_post_pws_customer_number, :canada_post_pws_contract_number]
     @preferences_GeneralSettings = [:units, :unit_multiplier, :default_weight, :handling_fee, 
       :max_weight_per_package, :test_mode]


### PR DESCRIPTION
Previous commit introduced an extra `test_mode` settings into the
CanadaPostPws preferences.

It is already included in the general settings.

Should fix build failures in #38 