### PR TITLE
Remove carmen from dependencies

### DIFF
--- a/solidus_active_shipping.gemspec
+++ b/solidus_active_shipping.gemspec
@@ -33,5 +33,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'capybara-screenshot'
   s.add_development_dependency 'ffaker'
-  s.add_dependency 'carmen', '~> 1.0.0'
 end


### PR DESCRIPTION
Removes carmen as a runtime dependency. It is a runtime dependency of core. It's also only ever used in specs.