### PR TITLE
Fix deprecation warning for `Order#update!`

### DIFF
--- a/spec/factories/order_factory_override.rb
+++ b/spec/factories/order_factory_override.rb
@@ -40,7 +40,11 @@ FactoryGirl.define do
 
       order.shipments.reload
 
-      order.update!
+      if SolidusSupport.solidus_gem_version < Gem::Version.new('2.4.x')
+        order.update!
+      else
+        order.recalculate
+      end
     end
   end
 end


### PR DESCRIPTION
Solidus wants us to use `Order#recalculate` instead.

[Deprecation notice](https://github.com/solidusio/solidus/blob/1c0d0bbbdd9f11391698d24dbcfd181300d07ff5/core/app/models/spree/order.rb#L253-L260)