### PR TITLE
Use Spree::ActiveShipping::Config

### DIFF
--- a/app/controllers/spree/admin/active_shipping_settings_controller.rb
+++ b/app/controllers/spree/admin/active_shipping_settings_controller.rb
@@ -10,11 +10,11 @@ class Spree::Admin::ActiveShippingSettingsController < Spree::Admin::BaseControl
     @preferences_GeneralSettings = [:units, :unit_multiplier, :default_weight, :handling_fee, 
       :max_weight_per_package, :test_mode]
 
-    @config = Spree::ActiveShippingConfiguration.new
+    @config = Spree::ActiveShipping::Config
   end
 
   def update
-    config = Spree::ActiveShippingConfiguration.new
+    config = Spree::ActiveShipping::Config
 
     params.each do |name, value|
       next unless config.has_preference? name

--- a/solidus_active_shipping.gemspec
+++ b/solidus_active_shipping.gemspec
@@ -32,5 +32,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'vcr'
   s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'capybara-screenshot'
+  s.add_development_dependency 'ffaker'
   s.add_dependency 'carmen', '~> 1.0.0'
 end

--- a/spec/controllers/admin/active_shipping_settings_controller_spec.rb
+++ b/spec/controllers/admin/active_shipping_settings_controller_spec.rb
@@ -12,7 +12,7 @@ describe Spree::Admin::ActiveShippingSettingsController do
   end
 
   context '#update' do
-    let(:config) { Spree::ActiveShippingConfiguration.new }
+    let(:config) { Spree::ActiveShipping::Config }
 
     context 'with existing value' do
       around do |example|

--- a/spec/support/shared_contexts/shipping_carriers/canada_post_pws.rb
+++ b/spec/support/shared_contexts/shipping_carriers/canada_post_pws.rb
@@ -1,12 +1,11 @@
 shared_context 'Canada Post PWS setup' do
   before do
     WebMock.allow_net_connect!
-    config = Spree::ActiveShippingConfiguration.new
-    config.canada_post_pws_userid = '6e93d53968881714'
-    config.canada_post_pws_password = '0bfa9fcb9853d1f51ee57a'
-    config.canada_post_pws_customer_number = '2004381'
-    config.canada_post_pws_contract_number = '42708517'
-    config.test_mode = true
+    Spree::ActiveShipping::Config[:canada_post_pws_userid] = '6e93d53968881714'
+    Spree::ActiveShipping::Config[:canada_post_pws_password] = '0bfa9fcb9853d1f51ee57a'
+    Spree::ActiveShipping::Config[:canada_post_pws_customer_number] = '2004381'
+    Spree::ActiveShipping::Config[:canada_post_pws_contract_number] = '42708517'
+    Spree::ActiveShipping::Config[:test_mode] = true
   end
 
   after do

--- a/spec/support/shared_contexts/shipping_carriers/fedex.rb
+++ b/spec/support/shared_contexts/shipping_carriers/fedex.rb
@@ -1,12 +1,11 @@
 shared_context 'FedEx setup' do
   before do
     WebMock.allow_net_connect!
-    config = Spree::ActiveShippingConfiguration.new
-    config.fedex_login = '118723830'
-    config.fedex_password = 'UGu5boYODXZ2GEDyUN4Xi1v8E'
-    config.fedex_account = '510087143'
-    config.fedex_key = 'xkBPuqiFmGrOU4jL'
-    config.test_mode = true
+    Spree::ActiveShipping::Config[:fedex_login] = '118723830'
+    Spree::ActiveShipping::Config[:fedex_password] = 'UGu5boYODXZ2GEDyUN4Xi1v8E'
+    Spree::ActiveShipping::Config[:fedex_account] = '510087143'
+    Spree::ActiveShipping::Config[:fedex_key] = 'xkBPuqiFmGrOU4jL'
+    Spree::ActiveShipping::Config[:test_mode] = true
   end
 
   after do

--- a/spec/support/shared_contexts/shipping_carriers/ups.rb
+++ b/spec/support/shared_contexts/shipping_carriers/ups.rb
@@ -1,11 +1,10 @@
 shared_context 'UPS setup' do
   before do
     WebMock.allow_net_connect!
-    shipping_config = Spree::ActiveShippingConfiguration.new
-    shipping_config.ups_login = 'solidusdev'
-    shipping_config.ups_password = 'S0lidusdev'
-    shipping_config.ups_key = '9D0B1B1E0A6389A8'
-    shipping_config.test_mode = true
+    Spree::ActiveShipping::Config[:ups_login] = 'solidusdev'
+    Spree::ActiveShipping::Config[:ups_password] = 'S0lidusdev'
+    Spree::ActiveShipping::Config[:ups_key] = '9D0B1B1E0A6389A8'
+    Spree::ActiveShipping::Config[:test_mode] = true
   end
 
   after do


### PR DESCRIPTION
After solidusio/solidus@ec87854 static preferences have become the default. This means that we should use the global instance of `Spree::ActiveShipping::Config` to set and retrieve our preferences. The specs were failing because we were using the old way of persisting preferences via the database (which has become an opt-in legacy option). Instead of taking the legacy approach to preferences, this PR updates the code to use the global instance of `Spree::ActiveShipping::Config` that is assigned in the initializer, instead of creating new instances of the preferences each time.

**EDIT**: This PR also adds ffaker as a development dependency in the gemspec. It was removed as a runtime dependency of Solidus.