### PR TITLE
Remove precompile of admin/product_packages/index.js

### DIFF
--- a/app/views/spree/admin/product_packages/index.html.erb
+++ b/app/views/spree/admin/product_packages/index.html.erb
@@ -2,10 +2,6 @@
   <li><%= link_to_with_icon('icon-plus', Spree.t(:new_package), new_admin_product_product_package_url(@product), :id => 'new_product_package_link', :class => 'button') %></li>
 <% end %>
 
-<% content_for :head do %>
-  <%= javascript_include_tag 'admin/product_packages/index.js' %>
-<% end %>
-
 <%# This partial was remove in solidus 1.2 but that is also when Spree.solidus_version was added %>
 <%= render :partial => 'spree/admin/shared/product_sub_menu' if !Spree.respond_to?(:solidus_version) %>
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Packages' } %>

--- a/lib/solidus_active_shipping/engine.rb
+++ b/lib/solidus_active_shipping/engine.rb
@@ -37,7 +37,6 @@ module SolidusActiveShipping
       app.config.assets.precompile += %w[
         admin/product_packages/new.js
         admin/product_packages/edit.js
-        admin/product_packages/index.js
       ]
     end
   end


### PR DESCRIPTION
This file was removed with this commit
https://github.com/solidusio-contrib/solidus_active_shipping/commit/23064ac234109c79ed283ff0f5ee76a8df0e9d84
but the precompilation and the inclusion is still here.